### PR TITLE
Improve standard contract deployment within IMA mapping wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ All features require `wagmi` + `react-query` context, exporting:
 
 Current features include:
 
-1. network
-2. interim (domain TBD)
+1. network (primitives)
+2. control
 3. analytics
 4. bridge (token bridging)
 5. icm (interchain messaging)

--- a/src/features/bridge/hooks.ts
+++ b/src/features/bridge/hooks.ts
@@ -1,8 +1,3 @@
-import {
-  useSContractApi,
-  useSContractRead,
-  useSContractWrite,
-} from '@/features/network/hooks';
 /**
  * @namespace Bridge
  * @module BridgeHooks
@@ -13,12 +8,14 @@ import { CONTRACT } from '@/features/network/contract';
 import {
   useExplorer,
   useSContract,
+  useSContractApi,
+  useSContractRead,
   useSContractReads,
+  useSContractWrite,
 } from '@/features/network/hooks';
 import { NETWORK, TOKEN_STANDARD } from '@/features/network/literals';
 import { ConnectionStatus } from '@/features/network/types';
 import { useQuery } from '@tanstack/react-query';
-
 import { ethers } from 'ethers';
 import { useNetwork } from 'wagmi';
 import { toSentenceCase } from '../../utils';

--- a/src/features/control/hooks.ts
+++ b/src/features/control/hooks.ts
@@ -231,9 +231,9 @@ export function useSTokenDeploy(props: DeployStandardProps) {
     isPreWhitelisted: isEoaWhitelisted.data,
     shouldManualDeploy: !shouldWhitelist,
     deploy: writeAsync && {
-      isSuccess: deployment.isSuccess,
-      isError: deployment.isError,
-      isLoading: deployment.isLoading,
+      ...deployment,
+      mutate: undefined,
+      mutateAsync: undefined,
       writeAsync,
     },
   };

--- a/src/features/interim/hooks.ts
+++ b/src/features/interim/hooks.ts
@@ -1,17 +1,22 @@
-import { useSContractWrite } from '@/features/network/hooks';
 /**
  * @namespace Config
  * @module ConfigHooks
  */
-
-import { getAbi } from '@/features/network/abi/abi';
-import { useSContractApi, useSContractReads } from '@/features/network/hooks';
-import { SCHAIN_CONFIG_CONTROLLER_ADDRESS } from '@skaleproject/constants/lib/addresses/predeployed';
-
-const configControllerContract = {
-  address: `${SCHAIN_CONFIG_CONTROLLER_ADDRESS}` as `0x${string}`,
-  abi: getAbi('CONFIG_CONTROLLER'),
-} as const;
+import ERC20Standard from '@/features/network/abi/erc20-standard.json';
+import {
+  useSContractApi,
+  useSContractRead,
+  useSContractReads,
+  useSContractRoles,
+  useSContractWrite,
+} from '@/features/network/hooks';
+import { TOKEN_STANDARD } from '@/features/network/literals';
+import { useMutation } from '@tanstack/react-query';
+import { BigNumber, ContractFactory } from 'ethers';
+import { useMemo } from 'react';
+import { useAccount, useSigner } from 'wagmi';
+const standards = Object.values(TOKEN_STANDARD);
+type TokenStandard = Uppercase<(typeof standards)[number]['name']>;
 
 export function useConfigController() {
   const {
@@ -90,5 +95,137 @@ export function useFcd() {
     toggle: writer.write,
     toggleAsync: writer.writeAsync,
     refetch,
+  };
+}
+
+type DeployProps = {
+  name: string;
+  symbol: string;
+  decimals: number;
+};
+
+type DeployStandardProps = DeployProps & {
+  standard: Lowercase<TokenStandard>;
+};
+
+const STANDARD_CONTRACT: {
+  [key in TokenStandard]: { abi: any; bytecode: string };
+} = {
+  ERC20: {
+    abi: ERC20Standard['abi'],
+    bytecode: ERC20Standard['bytecode'],
+  },
+};
+
+/**
+ * Deploy an ERC** standard contract with minting and burning capability
+ * @param props
+ * @returns
+ */
+function useDeployStandardContract(props: DeployStandardProps) {
+  const { name, symbol, decimals, standard } = props;
+  const { data: signer } = useSigner();
+  const standardKey = standard && (standard.toUpperCase() as TokenStandard);
+  return useMutation({
+    mutationKey: ['custom', 'ima-deployment', props],
+    mutationFn: async () => {
+      const { abi, bytecode } = STANDARD_CONTRACT[standardKey];
+      if (!abi || !bytecode) {
+        return;
+      }
+      const factory = new ContractFactory(abi, bytecode, signer);
+      const contract = await factory.deploy(
+        name,
+        symbol,
+        BigNumber.from(decimals),
+        {
+          gasLimit: 1500000,
+          gasPrice: 100000,
+        },
+      );
+      await contract.deployed();
+      return contract;
+    },
+  });
+}
+
+/**
+ * Deploy ERC standard token on SChain with permissioned flow
+ * @todo revise with explicit rules
+ * @param param0
+ */
+export function useSTokenDeploy(props: DeployStandardProps) {
+  const account = useAccount();
+
+  const deployment = useDeployStandardContract(props);
+
+  const isMultisigOwner = useSContractRead('MULTISIG_WALLET', {
+    enabled: !!account.address,
+    name: 'isOwner',
+    args: [account.address],
+  });
+  const msigReqdConfirms = useSContractRead('MULTISIG_WALLET', {
+    name: 'required',
+  });
+
+  const roles = useSContractRoles('CONFIG_CONTROLLER', [
+    'DEPLOYER_ADMIN_ROLE',
+    'DEPLOYER_ROLE',
+  ]);
+  const {
+    data: [deployerAdminRole, deployerRole],
+  } = roles;
+  const eoaHasDeployerAdminRole = deployerAdminRole.permissions.signer === true;
+  const eoaHasDeployerRole = deployerRole.permissions.signer === true;
+
+  const addSelfToWhitelist = useSContractWrite('CONFIG_CONTROLLER', {
+    enabled: !!account.address,
+    name: 'addToWhitelist',
+    args: [account.address],
+  });
+  const removeSelfFromWhitelist = useSContractWrite('CONFIG_CONTROLLER', {
+    enabled: !!account.address,
+    name: 'removeFromWhitelist',
+    args: [account.address],
+  });
+
+  const isLoadingReads = [isMultisigOwner, msigReqdConfirms, roles].some(
+    (i) => i.isLoading,
+  );
+
+  if (!eoaHasDeployerRole && eoaHasDeployerAdminRole) {
+  }
+
+  const sequencedWriters = [
+    addSelfToWhitelist,
+    {
+      ...deployment,
+      writeAsync: deployment.mutateAsync && (() => deployment.mutateAsync()),
+    },
+    removeSelfFromWhitelist,
+  ];
+  const writeAsync = useMemo(
+    () => {
+      if (
+        isLoadingReads ||
+        msigReqdConfirms.data === 1 ||
+        sequencedWriters.some((writer) => !writer.writeAsync)
+      ) {
+        return;
+      }
+      return async () => {
+        for await (const writer of sequencedWriters) {
+          await writer.writeAsync?.(true);
+        }
+      };
+    },
+    sequencedWriters.map((writer) => writer.writeAsync),
+  );
+
+  return {
+    isLoading: sequencedWriters.some((w) => w.isLoading),
+    isSuccess: sequencedWriters.some((w) => w.isSuccess),
+    isError: sequencedWriters.some((w) => w.isError),
+    writeAsync,
   };
 }

--- a/src/screens/ChainManager/ChainManager.tsx
+++ b/src/screens/ChainManager/ChainManager.tsx
@@ -1,6 +1,6 @@
 import Card from '@/components/Card/Card';
 
-import { useConfigController, useFcd, useMtm } from '@/features/interim/hooks';
+import { useConfigController, useFcd, useMtm } from '@/features/control/hooks';
 import { useCallback, useEffect, useState } from 'react';
 
 import AlertDialog from '@/components/AlertDialog/AlertDialog';

--- a/src/screens/ImaManager/ImaManager.tsx
+++ b/src/screens/ImaManager/ImaManager.tsx
@@ -245,7 +245,9 @@ const SelectedPeerChainItem = ({
               <>
                 <span className="font-medium">Mapped Tokens: </span>
                 <Dialog
-                  title={`${selectedStandard?.label} Tokens`}
+                  title={`${
+                    selectedStandard ? selectedStandard.label : ''
+                  } Tokens`}
                   description={''}
                   trigger={
                     <button className="">

--- a/src/views/Layout/Layout.tsx
+++ b/src/views/Layout/Layout.tsx
@@ -10,7 +10,7 @@ import { ConnectKitButton } from 'connectkit';
 import { FcdIcon, GithubIcon, MtmIcon } from '@/components/Icons/Icons';
 import RoleList from '@/elements/RoleList/RoleList';
 import RouterCrumb from '@/elements/RouterCrumb/RouterCrumb';
-import { useConfigController } from '@/features/interim/hooks';
+import { useConfigController } from '@/features/control/hooks';
 import { FlagIcon } from '@heroicons/react/24/solid';
 import {
   CaretDownIcon,


### PR DESCRIPTION
- `interim` feature is now called `control` and allows network level configurations
- `control` feature exports two standard contract deployment hooks, one primitive, and another with implicit permission flow
- ima token mapping flow uses deployment hooks from `control`